### PR TITLE
Copyright header changes for client app

### DIFF
--- a/Source/DIConnect/ClientApp/jest.config.js
+++ b/Source/DIConnect/ClientApp/jest.config.js
@@ -1,5 +1,5 @@
 ﻿// <copyright file="jest.config.js" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/App.test.tsx
+++ b/Source/DIConnect/ClientApp/src/App.test.tsx
@@ -1,5 +1,5 @@
 // <copyright file="App.test.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/App.tsx
+++ b/Source/DIConnect/ClientApp/src/App.tsx
@@ -1,5 +1,5 @@
 // <copyright file="App.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/actions/index.ts
+++ b/Source/DIConnect/ClientApp/src/actions/index.ts
@@ -1,5 +1,5 @@
 // <copyright file="index.ts" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/apis/__mocks__/appSettingsApi.ts
+++ b/Source/DIConnect/ClientApp/src/apis/__mocks__/appSettingsApi.ts
@@ -1,5 +1,5 @@
 ﻿// <copyright file="appSettingsApi.ts" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/apis/__mocks__/employeeResourceGroupApi.ts
+++ b/Source/DIConnect/ClientApp/src/apis/__mocks__/employeeResourceGroupApi.ts
@@ -1,5 +1,5 @@
 ﻿// <copyright file="employeeResourceGroupApi.ts" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/apis/__mocks__/teamDataApi.ts
+++ b/Source/DIConnect/ClientApp/src/apis/__mocks__/teamDataApi.ts
@@ -1,5 +1,5 @@
 ﻿// <copyright file="teamDataApi.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/apis/appSettingsApi.ts
+++ b/Source/DIConnect/ClientApp/src/apis/appSettingsApi.ts
@@ -1,5 +1,5 @@
 // <copyright file="appSettingsApi.ts" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/apis/axiosJWTDecorator.ts
+++ b/Source/DIConnect/ClientApp/src/apis/axiosJWTDecorator.ts
@@ -1,5 +1,5 @@
 // <copyright file="axiosJWTDecorator.ts" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/apis/employeeResourceGroupApi.ts
+++ b/Source/DIConnect/ClientApp/src/apis/employeeResourceGroupApi.ts
@@ -1,5 +1,5 @@
 // <copyright file="employeeResourceGroupApi.ts" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/apis/knowledgeBaseSettingsApi.ts
+++ b/Source/DIConnect/ClientApp/src/apis/knowledgeBaseSettingsApi.ts
@@ -1,5 +1,5 @@
 // <copyright file="knowledgeBaseSettingsApi.ts" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/apis/messageListApi.ts
+++ b/Source/DIConnect/ClientApp/src/apis/messageListApi.ts
@@ -1,5 +1,5 @@
 // <copyright file="messageListApi.ts" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/apis/teamDataApi.ts
+++ b/Source/DIConnect/ClientApp/src/apis/teamDataApi.ts
@@ -1,5 +1,5 @@
 ﻿// <copyright file="teamDataApi.ts" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/AdaptiveCard/adaptiveCard.ts
+++ b/Source/DIConnect/ClientApp/src/components/AdaptiveCard/adaptiveCard.ts
@@ -1,5 +1,5 @@
 // <copyright file="adaptiveCard.ts" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/ConfigurationTab/configurationTab.tsx
+++ b/Source/DIConnect/ClientApp/src/components/ConfigurationTab/configurationTab.tsx
@@ -1,5 +1,5 @@
 ﻿// <copyright file="configurationTab.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/ConfigurationTab/updateKnowledgeBaseId.tsx
+++ b/Source/DIConnect/ClientApp/src/components/ConfigurationTab/updateKnowledgeBaseId.tsx
@@ -1,5 +1,5 @@
 // <copyright file="updateKnowledgeBaseId.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/DraftMessages/draftMessages.tsx
+++ b/Source/DIConnect/ClientApp/src/components/DraftMessages/draftMessages.tsx
@@ -1,5 +1,5 @@
 // <copyright file="draftMessages.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/EmployeeResourceGroup/__tests__/createNewGroup.test.tsx
+++ b/Source/DIConnect/ClientApp/src/components/EmployeeResourceGroup/__tests__/createNewGroup.test.tsx
@@ -1,5 +1,5 @@
 ﻿// <copyright file="createNewGroup.test.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/EmployeeResourceGroup/createNewGroup.tsx
+++ b/Source/DIConnect/ClientApp/src/components/EmployeeResourceGroup/createNewGroup.tsx
@@ -1,5 +1,5 @@
 // <copyright file="createNewGroup.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.s
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/EmployeeResourceGroup/teamChannelTab.tsx
+++ b/Source/DIConnect/ClientApp/src/components/EmployeeResourceGroup/teamChannelTab.tsx
@@ -1,5 +1,5 @@
 ﻿// <copyright file="teamChannelTab.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/EmployeeResourceGroup/updateResouceGroup.tsx
+++ b/Source/DIConnect/ClientApp/src/components/EmployeeResourceGroup/updateResouceGroup.tsx
@@ -1,5 +1,5 @@
 // <copyright file="updateResouceGroup.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/ErrorPage/errorPage.tsx
+++ b/Source/DIConnect/ClientApp/src/components/ErrorPage/errorPage.tsx
@@ -1,5 +1,5 @@
 // <copyright file="errorPage.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/FilterBar/filterBar.tsx
+++ b/Source/DIConnect/ClientApp/src/components/FilterBar/filterBar.tsx
@@ -1,5 +1,5 @@
 ﻿// <copyright file="filterBar.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/JoinResourceGroup/_tests_/card.test.tsx
+++ b/Source/DIConnect/ClientApp/src/components/JoinResourceGroup/_tests_/card.test.tsx
@@ -1,5 +1,5 @@
 // <copyright file="card.test.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/JoinResourceGroup/_tests_/discoverResourceGroups.test.tsx
+++ b/Source/DIConnect/ClientApp/src/components/JoinResourceGroup/_tests_/discoverResourceGroups.test.tsx
@@ -1,5 +1,5 @@
 ﻿// <copyright file="discoverResourceGroups.test.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/JoinResourceGroup/card.tsx
+++ b/Source/DIConnect/ClientApp/src/components/JoinResourceGroup/card.tsx
@@ -1,5 +1,5 @@
 ﻿// <copyright file="card.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/JoinResourceGroup/discoverResourceGroups.tsx
+++ b/Source/DIConnect/ClientApp/src/components/JoinResourceGroup/discoverResourceGroups.tsx
@@ -1,5 +1,5 @@
 ﻿// <copyright file="discoverResourceGroups.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/Messages/messages.tsx
+++ b/Source/DIConnect/ClientApp/src/components/Messages/messages.tsx
@@ -1,5 +1,5 @@
 // <copyright file="messages.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/NewMessage/newMessage.tsx
+++ b/Source/DIConnect/ClientApp/src/components/NewMessage/newMessage.tsx
@@ -1,5 +1,5 @@
 // <copyright file="newMessage.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/OverFlow/draftMessageOverflow.tsx
+++ b/Source/DIConnect/ClientApp/src/components/OverFlow/draftMessageOverflow.tsx
@@ -1,5 +1,5 @@
 // <copyright file="draftMessageOverflow.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/OverFlow/sentMessageOverflow.tsx
+++ b/Source/DIConnect/ClientApp/src/components/OverFlow/sentMessageOverflow.tsx
@@ -1,5 +1,5 @@
 // <copyright file="sentMessageOverflow.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/SendConfirmationTaskModule/sendConfirmationTaskModule.tsx
+++ b/Source/DIConnect/ClientApp/src/components/SendConfirmationTaskModule/sendConfirmationTaskModule.tsx
@@ -1,5 +1,5 @@
 // <copyright file="sendConfirmationTaskModule.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/SignInPage/signInPage.tsx
+++ b/Source/DIConnect/ClientApp/src/components/SignInPage/signInPage.tsx
@@ -1,5 +1,5 @@
 // <copyright file="signInPage.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/SignInPage/signInSimpleEnd.tsx
+++ b/Source/DIConnect/ClientApp/src/components/SignInPage/signInSimpleEnd.tsx
@@ -1,5 +1,5 @@
 // <copyright file="signInSimpleEnd.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/SignInPage/signInSimpleStart.tsx
+++ b/Source/DIConnect/ClientApp/src/components/SignInPage/signInSimpleStart.tsx
@@ -1,5 +1,5 @@
 // <copyright file="signInSimpleStart.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/StatusTaskModule/statusTaskModule.tsx
+++ b/Source/DIConnect/ClientApp/src/components/StatusTaskModule/statusTaskModule.tsx
@@ -1,5 +1,5 @@
 // <copyright file="statusTaskModule.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/TabContainer/tabContainer.tsx
+++ b/Source/DIConnect/ClientApp/src/components/TabContainer/tabContainer.tsx
@@ -1,5 +1,5 @@
 // <copyright file="tabContainer.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/_tests_/config.test.tsx
+++ b/Source/DIConnect/ClientApp/src/components/_tests_/config.test.tsx
@@ -1,5 +1,5 @@
 // <copyright file="config.test.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/checkboxWrapper.tsx
+++ b/Source/DIConnect/ClientApp/src/components/checkboxWrapper.tsx
@@ -1,5 +1,5 @@
 ﻿// <copyright file="checkboxWrapper.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/config.tsx
+++ b/Source/DIConnect/ClientApp/src/components/config.tsx
@@ -1,5 +1,5 @@
 // <copyright file="config.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/popup-menu/popupMenuCheckboxesContent.tsx
+++ b/Source/DIConnect/ClientApp/src/components/popup-menu/popupMenuCheckboxesContent.tsx
@@ -1,5 +1,5 @@
 ﻿// <copyright file="popupMenuCheckboxesContent.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/popup-menu/popupMenuWrapper.tsx
+++ b/Source/DIConnect/ClientApp/src/components/popup-menu/popupMenuWrapper.tsx
@@ -1,5 +1,5 @@
 ﻿// <copyright file="popupMenuWrapper.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/components/teamChannelConfig.tsx
+++ b/Source/DIConnect/ClientApp/src/components/teamChannelConfig.tsx
@@ -1,5 +1,5 @@
 ﻿// <copyright file="teamChannelConfig.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/configVariables.ts
+++ b/Source/DIConnect/ClientApp/src/configVariables.ts
@@ -1,5 +1,5 @@
 // <copyright file="configVariables.ts" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/constants/constants.ts
+++ b/Source/DIConnect/ClientApp/src/constants/constants.ts
@@ -1,5 +1,5 @@
 ﻿// <copyright file="constants.ts" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/constants/groupType.ts
+++ b/Source/DIConnect/ClientApp/src/constants/groupType.ts
@@ -1,5 +1,5 @@
 ﻿// <copyright file="groupType.ts" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/i18n.ts
+++ b/Source/DIConnect/ClientApp/src/i18n.ts
@@ -1,5 +1,5 @@
 // <copyright file="i18n.ts" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/index.tsx
+++ b/Source/DIConnect/ClientApp/src/index.tsx
@@ -1,5 +1,5 @@
 // <copyright file="index.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/jest/setup.js
+++ b/Source/DIConnect/ClientApp/src/jest/setup.js
@@ -1,5 +1,5 @@
 ﻿// <copyright file="setup.ts" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/models/employeeResourceGroup.ts
+++ b/Source/DIConnect/ClientApp/src/models/employeeResourceGroup.ts
@@ -1,5 +1,5 @@
 ﻿// <copyright file="employeeResourceGroup.ts" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/react-app-env.d.ts
+++ b/Source/DIConnect/ClientApp/src/react-app-env.d.ts
@@ -1,5 +1,5 @@
 // <copyright file="react-app-env.d.ts" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/reducers/index.ts
+++ b/Source/DIConnect/ClientApp/src/reducers/index.ts
@@ -1,5 +1,5 @@
 // <copyright file="index.ts" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/serviceWorker.ts
+++ b/Source/DIConnect/ClientApp/src/serviceWorker.ts
@@ -1,5 +1,5 @@
 // <copyright file="serviceWorker.ts" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 

--- a/Source/DIConnect/ClientApp/src/utility/imageutility.tsx
+++ b/Source/DIConnect/ClientApp/src/utility/imageutility.tsx
@@ -1,5 +1,5 @@
 // <copyright file="imageutility.tsx" company="Microsoft Corporation">
-// Copyright (c) Microsoft.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 // </copyright>
 


### PR DESCRIPTION
The changes includes all client app ts and tsx file to use revised header i.e. replace Microsoft with Microsoft Corporation